### PR TITLE
feat(web): setup routes and components for static pages - Closes #6

### DIFF
--- a/src/app/(public)/about-us/page.tsx
+++ b/src/app/(public)/about-us/page.tsx
@@ -1,0 +1,10 @@
+// app/(public)/about-us/page.tsx
+import AboutUsContent from "@/components/public/web/features/about-us/AboutUsContent";
+
+export default function AboutUsPage() {
+  return (
+    <section className="min-h-screen px-4 py-8">
+      <AboutUsContent />
+    </section>
+  );
+}

--- a/src/app/(public)/contact-us/page.tsx
+++ b/src/app/(public)/contact-us/page.tsx
@@ -1,0 +1,9 @@
+import ContactUsContent from "@/components/public/web/features/contact-us/ContactUsContent";
+
+export default function ContactUsPage() {
+  return (
+    <section className="min-h-screen px-4 py-8">
+      <ContactUsContent />
+    </section>
+  );
+}

--- a/src/app/(public)/disclaimer/page.tsx
+++ b/src/app/(public)/disclaimer/page.tsx
@@ -1,0 +1,9 @@
+import DisclaimerContent from "@/components/public/web/features/disclaimer/DisclaimerContent";
+
+export default function DisclaimerPage() {
+  return (
+    <section className="min-h-screen px-4 py-8">
+      <DisclaimerContent />
+    </section>
+  );
+}

--- a/src/app/(public)/inquiry/page.tsx
+++ b/src/app/(public)/inquiry/page.tsx
@@ -1,0 +1,9 @@
+import InquiryContent from "@/components/public/web/features/inquiry/InquiryContent";
+
+export default function InquiryPage() {
+  return (
+    <section className="min-h-screen px-4 py-8">
+      <InquiryContent />
+    </section>
+  );
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,19 +1,10 @@
 // app/(public)/layout.tsx
-
 "use client";
 
-import React, { ReactNode } from "react";
 import Header from "@/components/public/web/features/base/header";
 import Footer from "@/components/public/web/features/base/footer";
 
-/**
- * PublicLayout wraps public-facing pages with a consistent header and footer.
- */
-interface PublicLayoutProps {
-  children: ReactNode;
-}
-
-export default function PublicLayout({ children }: PublicLayoutProps) {
+export default function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col min-h-screen">
       <Header />

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,11 +1,9 @@
-// src/app/(public)/page.tsx
+
 
 import React from "react";
 import HomeLayout from "@/components/public/web/layout/HomeLayout";
 
-/**
- * HomePage - the public-facing landing page of the application.
- */
+
 export default function HomePage() {
   return <HomeLayout />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-// src/app/layout.tsx
+// app/layout.tsx
 
 import "./globals.css";
 import { Geist, Geist_Mono } from "next/font/google";
@@ -15,7 +15,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body
-        // IMPORTANT CHANGE: Replaced inline styles with Tailwind classes for layout consistency
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
       >
         {children}

--- a/src/components/public/web/features/about-us/AboutUsContent.tsx
+++ b/src/components/public/web/features/about-us/AboutUsContent.tsx
@@ -1,0 +1,11 @@
+// components/public/web/features/about-us/AboutUsContent.tsx
+export default function AboutUsContent() {
+  return (
+    <div className="text-center text-lg text-gray-800">
+      <h1 className="text-3xl font-bold mb-4">About Us</h1>
+      <p>
+        Welcome to our company. We are committed to building scalable and impactful web solutions.
+      </p>
+    </div>
+  );
+}

--- a/src/components/public/web/features/base/header.tsx
+++ b/src/components/public/web/features/base/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import HeaderUI from "../../ui/headerUi"; // Correct relative path
+import HeaderUI from "../../ui/headerUi"; 
 
 const Header = () => {
   const logo = {
@@ -12,9 +12,9 @@ const Header = () => {
   const links = [
     { label: "Home", href: "/" },
     { label: "About", href: "/about-us" },
-    { label: "Contact", href: "/contact-us" }, // Changed /contact to /contact-us
-    { label: "Inquiry", href: "/inquiry" },     // Added Inquiry link
-    { label: "Disclaimer", href: "/disclaimer" }, // Added Disclaimer link
+    { label: "Contact", href: "/contact-us" },
+    { label: "Inquiry", href: "/inquiry" },     
+    { label: "Disclaimer", href: "/disclaimer" }, 
   ];
 
   return (

--- a/src/components/public/web/features/base/header.tsx
+++ b/src/components/public/web/features/base/header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import HeaderUI from "../../ui/headerUi";
+import HeaderUI from "../../ui/headerUi"; // Correct relative path
 
 const Header = () => {
   const logo = {
@@ -12,7 +12,9 @@ const Header = () => {
   const links = [
     { label: "Home", href: "/" },
     { label: "About", href: "/about-us" },
-    { label: "Contact", href: "/contact" },
+    { label: "Contact", href: "/contact-us" }, // Changed /contact to /contact-us
+    { label: "Inquiry", href: "/inquiry" },     // Added Inquiry link
+    { label: "Disclaimer", href: "/disclaimer" }, // Added Disclaimer link
   ];
 
   return (

--- a/src/components/public/web/features/contact-us/ContactUsContent.tsx
+++ b/src/components/public/web/features/contact-us/ContactUsContent.tsx
@@ -1,0 +1,10 @@
+export default function ContactUsContent() {
+  return (
+    <div className="text-center text-lg text-gray-800">
+      <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+      <p>
+        Reach out to us via email at support@example.com or call us at (123) 456-7890.
+      </p>
+    </div>
+  );
+}

--- a/src/components/public/web/features/disclaimer/DisclaimerContent.tsx
+++ b/src/components/public/web/features/disclaimer/DisclaimerContent.tsx
@@ -1,0 +1,12 @@
+// components/public/web/features/disclaimer/DisclaimerContent.tsx
+
+export default function DisclaimerContent() {
+  return (
+    <div className="text-center text-lg text-gray-800">
+      <h1 className="text-3xl font-bold mb-4">Disclaimer</h1>
+      <p>
+        The information on this website is for general informational purposes only and is not professional advice.
+      </p>
+    </div>
+  );
+}

--- a/src/components/public/web/features/inquiry/InquiryContent.tsx
+++ b/src/components/public/web/features/inquiry/InquiryContent.tsx
@@ -1,0 +1,10 @@
+export default function InquiryContent() {
+  return (
+    <div className="text-center text-lg text-gray-800">
+      <h1 className="text-3xl font-bold mb-4">Inquiry</h1>
+      <p>
+        For business or service-related inquiries, please use the form on this page or email us at inquiries@example.com.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds static pages for:

- /about-us
- /contact-us
- /inquiry
- /disclaimer

Each page uses the shared layout in `app/(public)/layout.tsx` and loads content from modular components in `components/public/web/features`.

Navigation links updated in `header.tsx`.

Closes #6
